### PR TITLE
Add support for multiple repositories

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,2 @@
 export const OWNER = `hasura`;
-export const REPO = `graphql-engine`;
+export const REPOS: string[] = [`graphql-engine`, `ddn-docs`];

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -10,10 +10,9 @@ import {
 } from "../types.js";
 
 const owner = config.OWNER;
-const repo = config.REPO;
 
 // fetchIssues will grab the current open issues in the repo, limiting itself to the first 100.
-export async function fetchIssues(): Promise<Issue[]> {
+export async function fetchIssues(repo: string): Promise<Issue[]> {
   const variables = {
     owner,
     repo,
@@ -56,7 +55,7 @@ export function parseIssue(anIssue: Issue): SheetRow {
 }
 
 // fetchDiscussions will grab the current unanswered discussions in the the repo, limiting itself to the first 100.
-export async function fetchDiscussions(): Promise<Discussion[]> {
+export async function fetchDiscussions(repo: string): Promise<Discussion[]> {
   const variables = {
     owner,
     repo,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,11 +15,18 @@ import {
   eliminateExistingIssues,
   eliminateExistingDiscussions,
 } from "./utils.js";
+import * as config from "./constants.js";
 
 const main = async () => {
   // Get the issues and discussions from GitHub
-  const issues = await fetchIssues();
-  const discussions = await fetchDiscussions();
+  const allIssues = await Promise.all(
+    config.REPOS.map((repo) => fetchIssues(repo)),
+  );
+  const issues = allIssues.flat();
+  const allDiscussions = await Promise.all(
+    config.REPOS.map((repo) => fetchDiscussions(repo)),
+  );
+  const discussions = allDiscussions.flat();
 
   // Get the list from the spreadsheet
   const currentRowsInSheet = await getRows();


### PR DESCRIPTION
Adds support for multiple repositories by modiygin the `REPO` const into `REPOS: string[]` and mapping over it when invoking the `fetch...()` functions.