### PR TITLE
Fix Discord URL generation

### DIFF
--- a/src/discord/index.ts
+++ b/src/discord/index.ts
@@ -20,7 +20,7 @@ export async function fetchThreads(): Promise<Thread[]> {
   return response.data.threads as Thread[];
 }
 
-// filterThreads() returns only the threads that are in the channels list (v2 and v3 help forums)
+// filterThreads() returns only the threads that are in the channels list (v2 and v3 help forums and promptql)
 // and also ensures we're only grabbing the last 30 days
 export async function filterThreads(threads: Thread[]): Promise<Thread[]> {
   let thirtyDaysAgo = new Date();
@@ -43,6 +43,7 @@ export async function filterThreads(threads: Thread[]): Promise<Thread[]> {
 
 // fetchFirstMessage() gets the first message in the thread
 export async function fetchFirstMessage(
+  parentId: string,
   threadId: string,
 ): Promise<MessageDetails> {
   try {
@@ -64,6 +65,7 @@ export async function fetchFirstMessage(
     const createdAt = messages[messages.length - 1].timestamp;
 
     return {
+      channelId: parentId,
       messageId,
       content,
       createdAt,

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ const main = async () => {
   const newIssues = eliminateExistingIssues(issues, currentRowsInSheet);
 
   if (newIssues.length < 1) {
-    console.log(`🍻 No new issues today`);
+    console.log(`🍻 No new GitHub issues`);
   } else {
     // For any issues that are new, summarize them using GPT and ship 'em
     for (const issue of newIssues) {
@@ -62,7 +62,7 @@ const main = async () => {
   );
 
   if (newDisucssions.length < 1) {
-    console.log(`🍻 No new discussions today`);
+    console.log(`🍻 No new GitHub discussion`);
   } else {
     for (const discussion of newDisucssions) {
       let parsed = parseDiscussion(discussion);
@@ -76,7 +76,10 @@ const main = async () => {
   const filteredThreads = await filterThreads(threads);
   const shapedMessages: MessageDetails[] = await Promise.all(
     filteredThreads.map(async (thread) => {
-      const messageDetails = await fetchFirstMessage(thread.id);
+      const messageDetails = await fetchFirstMessage(
+        thread.parent_id,
+        thread.id,
+      );
       return shapeDiscordRow(thread.name, messageDetails);
     }),
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,7 @@ export type Thread = {
 };
 
 export type MessageDetails = {
+  channelId: string;
   messageId: string;
   content: string;
   threadName?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,5 +87,6 @@ export function shapeDiscordRow(
 // createMessageLink() builds the URL structure for a Discord message so we can
 // easily add this into the SheetRow
 export function createMessageLink(message: MessageDetails): string {
-  return `https://www.discord.com/channels/${GUILD_ID}/${message.messageId}`;
+  // The format should be: https://www.discord.com/channels/GUILD_ID/CHANNEL_ID/threads/THREAD_ID
+  return `https://www.discord.com/channels/${GUILD_ID}/${message.channelId}/threads/${message.messageId}`;
 }


### PR DESCRIPTION
Fixes Discord URL generation to utilize the appropriate format: 

```plaintext
https://www.discord.com/channels/GUILD_ID/CHANNEL_ID/threads/THREAD_ID
```