### PR TITLE
Fix: Discord URL Generation

### DIFF
--- a/src/discord/index.ts
+++ b/src/discord/index.ts
@@ -24,7 +24,7 @@ export async function fetchThreads(): Promise<Thread[]> {
 // and also ensures we're only grabbing the last 30 days
 export async function filterThreads(threads: Thread[]): Promise<Thread[]> {
   let thirtyDaysAgo = new Date();
-  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 1);
 
   const recentThreads = threads.filter((thread) => {
     const isInChannel = CHANNEL_IDs.includes(thread.parent_id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ const main = async () => {
         thread.parent_id,
         thread.id,
       );
-      return shapeDiscordRow(thread.name, messageDetails);
+      return shapeDiscordRow(thread.name, thread.id, messageDetails);
     }),
   );
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ import { GUILD_ID } from "./constants.js";
 
 export function getYesterdayInISO(): string {
   const now = new Date();
-  now.setDate(now.getDate() - 30);
+  now.setDate(now.getDate() - 1);
   return now.toISOString();
 }
 
@@ -75,18 +75,12 @@ export function sortThreads(recentThreads: Thread[]): Thread[] {
 // exactly what a user is talking about
 export function shapeDiscordRow(
   threadName: string,
+  threadId: string,
   messageDetails: MessageDetails,
 ): MessageDetails {
   return {
     ...messageDetails,
     threadName,
-    url: createMessageLink(messageDetails),
+    url: `https://www.discord.com/channels/${GUILD_ID}/${threadId}`,
   };
-}
-
-// createMessageLink() builds the URL structure for a Discord message so we can
-// easily add this into the SheetRow
-export function createMessageLink(message: MessageDetails): string {
-  // The format should be: https://www.discord.com/channels/GUILD_ID/CHANNEL_ID/threads/THREAD_ID
-  return `https://www.discord.com/channels/${GUILD_ID}/${message.channelId}/threads/${message.messageId}`;
 }


### PR DESCRIPTION
Discord presented some confusing (read: varying) URL structures. Navigating to a thread directly will return a URL structure that fits what we were creating via `createMessageLink()`. However, by right-clicking on a thread and copying the address, a very simple structure that's simply the guild_id/thread_id is produced.

This should prevent any false positives and still capture all new threads as they come in. As such, I've also reset the Discord dates to -1 day instead of -30 days to prevent retroactively grabbing everything that's already in the spreadsheet.